### PR TITLE
detect file presence correctly

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+0.2.2
+- Fixed install regression caused by 0.2.1 README change
+
 0.2.1
 - Fixed setup.py accounting for wrong README
 

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -132,7 +132,7 @@ class FacebookAdsApi(object):
             this sdk.
     """
 
-    SDK_VERSION = '0.2.1'
+    SDK_VERSION = '0.2.2'
 
     API_VERSION = 'v2.1'
 

--- a/setup.py
+++ b/setup.py
@@ -25,16 +25,16 @@ except ImportError:
 import os
 
 this_dir = os.path.dirname(__file__)
-if os.path.isfile('README.rst'):
-    readme_filename = 'README.rst'
-elif os.path.isfile('README.md'):
-    readme_filename = 'README.md'
+if os.path.isfile(os.path.join(this_dir, 'README.rst')):
+    readme_basename = 'README.rst'
+elif os.path.isfile(os.path.join(this_dir, 'README.md')):
+    readme_basename = 'README.md'
 
-readme_filename = os.path.join(this_dir, readme_filename)
+readme_filename = os.path.join(this_dir, readme_basename)
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = 'facebookads'
-PACKAGE_VERSION = '0.2.1'
+PACKAGE_VERSION = '0.2.2'
 PACKAGE_AUTHOR = 'Facebook'
 PACKAGE_AUTHOR_EMAIL = ''
 PACKAGE_URL = 'https://github.com/facebook/facebook-python-ads-sdk'


### PR DESCRIPTION
This is what happens when I try to install the facebook ads SDK using pip:

```
$ sudo pip install facebookads
Downloading/unpacking facebookads
  Downloading facebookads-0.2.1.tar.gz (377kB): 377kB downloaded
  Running setup.py (path:/private/tmp/pip_build_root/facebookads/setup.py) egg_info for package facebookads
    Traceback (most recent call last):
      File "<string>", line 17, in <module>
      File "/private/tmp/pip_build_root/facebookads/setup.py", line 33, in <module>
        readme_filename = os.path.join(this_dir, readme_filename)
    NameError: name 'readme_filename' is not defined
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 17, in <module>

  File "/private/tmp/pip_build_root/facebookads/setup.py", line 33, in <module>

    readme_filename = os.path.join(this_dir, readme_filename)

NameError: name 'readme_filename' is not defined

----------------------------------------
Cleaning up...
Command python setup.py egg_info failed with error code 1 in /private/tmp/pip_build_root/facebookads
Storing debug log for failure in /Users/bhs/Library/Logs/pip.log
```

I believe the change here will address the above.
