### PR TITLE
Repair adgroup integration test.

### DIFF
--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -544,6 +544,7 @@ class AbstractCrudObject(AbstractObject):
                 files=files,
             )
             self._set_data(response.json())
+            self._clear_history()
 
             return self
 

--- a/facebookads/test/integration.py
+++ b/facebookads/test/integration.py
@@ -124,6 +124,7 @@ class FacebookAdsTestCase(unittest.TestCase):
             objects.AdGroup.Field.creative: {
                 objects.AdGroup.Field.Creative.creative_id: creative_id,
             },
+            objects.AdGroup.Field.status: objects.AdGroup.Status.paused,
         })
 
         return ad_group


### PR DESCRIPTION
Need to set `adgroup_status` in order for adgroup creation to succeed.

Need to clear history in `remote_create()`, otherwise subsequent
`remote_update()` tries to set the same fields. This especially fails trying
to update adgroup status while it's under review.
