### PR TITLE
Avoid dict comprehension syntax for Python 2.6 compatibility.

### DIFF
--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -1771,7 +1771,7 @@ class ReachFrequencyPrediction(AbstractCrudObject):
             self.Field.action: self.Action.reserve,
         }
         # Filter out None values.
-        params = {k: v for (k, v) in params.items() if v is not None}
+        params = dict((k, v) for k, v in params.items() if v is not None)
 
         response = self.get_api_assured().call(
             FacebookAdsApi.HTTP_METHOD_POST,


### PR DESCRIPTION
Dict comprehensions are a Python 2.7 feature, see
https://docs.python.org/3/whatsnew/2.7.html#python-3-1-features
