### PR TITLE
Add coverage support via coveralls.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ MANIFEST
 dist
 build
 .DS_Store
+/.coverage
 /.idea
 /.tox
 *.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,20 @@
 language: python
 python: 2.7
 env:
-  - TOX_ENV=py34
-  - TOX_ENV=py33
-  - TOX_ENV=py27
-  - TOX_ENV=py26
+  global:
+    - COVERALLS_CMD=true
+  matrix:
+    - TOXENV=py34
+    - TOXENV=py33
+    - TOXENV=py27
+    - TOXENV=py26
+    - COVERALLS_DEP=coveralls
+      COVERALLS_CMD=coveralls
+      COVERAGE_DEP=coverage
+      COVERAGE_CMD="coverage run --append --source=facebookads"
 install:
-  - pip install tox
+  - pip install tox $COVERALLS_DEP
 script:
-  - tox -e $TOX_ENV
+  - tox
+after_script:
+  - $COVERALLS_CMD

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ads API SDK for Python
 
 [![Build Status](https://travis-ci.org/facebook/facebook-python-ads-sdk.svg)](https://travis-ci.org/facebook/facebook-python-ads-sdk)
+[![Coverage Status](https://img.shields.io/coveralls/facebook/facebook-python-ads-sdk.svg)](https://coveralls.io/r/facebook/facebook-python-ads-sdk)
 
 ## The Ads SDK for Python provides an easy interface and abstraction to the Ads API.
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,8 @@ envlist = py26,py27,py33,py34
 
 [testenv]
 commands =
-    {envpython} -m facebookads.test.unit
-    {envpython} -m facebookads.test.integration
-    {envpython} -m facebookads.test.docs
+    {env:COVERAGE_CMD:python} -m facebookads.test.unit
+    {env:COVERAGE_CMD:python} -m facebookads.test.integration
+    {env:COVERAGE_CMD:python} -m facebookads.test.docs
 deps = -rrequirements.txt
+       {env:COVERAGE_DEP:}


### PR DESCRIPTION
Prior to pulling this, head over to https://coveralls.io and enable for
facebook/facebook-python-ads-sdk. Then pulling this should do the rest.

This depends on #18 so pull that first, otherwise this will just pull in those
same commits.

You can see an example of the result at https://coveralls.io/builds/1574215
