### PR TITLE
Fix AsyncJob.__nonzero__: KeyError

### DIFF
--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -2941,4 +2941,7 @@ class AsyncJob(CannotCreate, AbstractCrudObject):
         )
 
     def __nonzero__(self):
-        return self[self.Field.async_percent_completion] == 100
+        try:
+            return self[self.Field.async_percent_completion] == 100
+        except KeyError:
+            return False

--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -2945,3 +2945,5 @@ class AsyncJob(CannotCreate, AbstractCrudObject):
             return self[self.Field.async_percent_completion] == 100
         except KeyError:
             return False
+
+    __bool__ = __nonzero__  # python3 compat

--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -420,5 +420,24 @@ class VersionUtilsTestCase(unittest.TestCase):
         version_value = utils.version.get_version()
         assert re.search('[0-9]+\.[0-9]+\.[0-9]', version_value)
 
+
+class AsyncJobTestCase(unittest.TestCase):
+
+    def test_init(self):
+        async_job = objects.AsyncJob(objects.Insights)
+        self.assertEqual(async_job.target_objects_class, objects.Insights)
+
+    def test___nonzero__(self):
+        async_job = objects.AsyncJob(objects.Insights)
+        # no async_percent_completion
+        self.assertFalse(async_job)
+        # not 100
+        async_job[async_job.Field.async_percent_completion] = 42
+        self.assertFalse(async_job)
+        # 100
+        async_job[async_job.Field.async_percent_completion] = 100
+        self.assertTrue(async_job)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi there,

This PR includes a fix of `AsyncJob.__nonzero__` that could raise a `KeyError` if the `AsyncJob` was never read. I think it's not what we / I / users want.

Finally, I'd like to test extensively the `get_result()` method, and I'd like to use [this module](https://pypi.python.org/pypi/mock). It's kind of the best module to have mocks in your tests. I've used it for years ^^. Would you consider using it and if yes, where should I include it?

Cheers!
