### PR TITLE
Connection pool and Retry config for FacebookSession

### DIFF
--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -176,9 +176,12 @@ class FacebookAdsApi(object):
         app_id=None,
         app_secret=None,
         access_token=None,
-        account_id=None
+        account_id=None,
+        pool_maxsize=10,
+        max_retries=0
     ):
-        session = FacebookSession(app_id, app_secret, access_token)
+        session = FacebookSession(app_id, app_secret, access_token,
+                                  pool_maxsize, max_retries)
         api = cls(session)
         cls.set_default_api(api)
 

--- a/facebookads/session.py
+++ b/facebookads/session.py
@@ -26,6 +26,7 @@ import hashlib
 import hmac
 import requests
 import os
+from requests.adapters import HTTPAdapter
 
 
 class FacebookSession(object):
@@ -44,17 +45,30 @@ class FacebookSession(object):
     """
     GRAPH = 'https://graph.facebook.com'
 
-    def __init__(self, app_id=None, app_secret=None, access_token=None):
+    def __init__(self, app_id=None, app_secret=None, access_token=None,
+                 pool_maxsize=10, max_retries=0):
         """
         Initializes and populates the instance attributes with app_id,
         app_secret, access_token, appsecret_proof, and requests given arguments
         app_id, app_secret, and access_token.
+
+        Args:
+            pool_maxsize: you change the default Requests connection pool size
+                (useful for multi-threaded data loading scenarios)
+            max_retries: Requests library can do retries for you, by default it doesn't
         """
         self.app_id = app_id
         self.app_secret = app_secret
         self.access_token = access_token
 
+        self.pool_maxsize = pool_maxsize
+        self.max_retries = max_retries
+
         self.requests = requests.Session()
+        self.requests.mount(
+            'https://',
+            HTTPAdapter(pool_maxsize=self.pool_maxsize,
+                        max_retries=self.max_retries))
         self.requests.verify = os.path.join(
             os.path.dirname(__file__),
             'fb_ca_chain_bundle.crt',


### PR DESCRIPTION
1. I added pool_maxsize parameter to FacebookSession's **init**
   It's for multi-threaded data load usage scenario.
2. I added max_retries parameter to FacebookSession's **init**
   For a better network error handling. You can actually pass the requests.packages.urllib3.util.retry.Retry object, which supports pretty complex retry behavior.
   Comes handy in some unreliable networks far, far away from Facebook's data centers.
