### PR TITLE
Add lifetime to date presets

### DIFF
--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -2833,6 +2833,7 @@ class Insights(CannotCreate, CannotDelete, CannotUpdate, AbstractCrudObject):
         this_week = 'this_week'
         today = 'today'
         yesterday = 'yesterday'
+        lifetime = 'lifetime'
 
     class Increment(object):
         monthly = 'monthly'


### PR DESCRIPTION
This adds `lifetime` to the `date_preset` option used by the Insights API.
