### PR TITLE
Fix AsyncJob.__nonzero__ job complete check

### DIFF
--- a/facebookads/objects.py
+++ b/facebookads/objects.py
@@ -3406,7 +3406,8 @@ class AsyncJob(CannotCreate, AbstractCrudObject):
         )
 
     def __nonzero__(self):
-        return self[self.Field.async_percent_completion] == 100
+        return (self[self.Field.async_percent_completion] == 100 and 
+                self[self.Field.async_status] == 'Job Completed')
 
 
 class AdPlacePageSet(CannotDelete, AbstractCrudObject):


### PR DESCRIPTION
Async calls can return with `job['async_percent_completion'] == 100` yet still not be complete. The response looking like:

```
<AsyncJob> {
    "account_id": ".....",
    "async_percent_completion": 100,
    "async_status": "Job Running",
    "id": "6035747473269",
    "is_running": true,
    "report_run_id": "6035747473269",
    "time_ref": 1456266098
}
```

A subsequent call to `.get_result()` would fail with:

```
  Message: Call was not successful
  Method:  GET
  Path:    https://graph.facebook.com/v2.5/.../insights
  Params:  {}

  Status:  400
  Response:
    {
      "error": {
        "code": 2601, 
        "is_transient": true, 
        "error_subcode": 1815107, 
        "error_user_msg": "Sorry, the report cannot be loaded successfully. Please check if your job status is completed instead of failed or running before fetching the data.", 
        "error_user_title": "Loading Async Ads Report Failed", 
        "message": "Error accessing adreport job.", 
        "type": "OAuthException", 
        "fbtrace_id": "E/qCS/IDH7v"
      }
    }
```

The actually completed response looks like:

```
<AsyncJob> {
    "account_id": "164313463899989",
    "async_percent_completion": 100,
    "async_status": "Job Completed",
    "id": "6035747473269",
    "is_running": true,
    "report_run_id": "6035747473269",
    "time_completed": 1456266101,
    "time_ref": 1456266098
}
```

This patch also checks for `job['async_status'] == 'Job Completed'` for that reason.  Although the `async_percent_completion` check is irrelevant in light of this.
