### PR TITLE
Add include_headers parameter for batch operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,12 @@ Once you're finished adding calls to the batch, you can send off the request:
 my_api_batch.execute()
 ```
 
+You can specify not to include headers for better performance:
+
+```python
+my_api_batch.execute(include_headers=False)
+```
+
 Please follow <a href="https://developers.facebook.com/docs/graph-api/making-multiple-requests">
 batch call guidelines in the Marketing API documentation</a>. There are optimal
 numbers of calls per batch. In addition, you may need to watch out that for rate

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -457,13 +457,17 @@ class FacebookAdsApiBatch(object):
             request=request,
         )
 
-    def execute(self):
+    def execute(self, include_headers=True):
         """Makes a batch call to the api associated with this object.
         For each individual call response, calls the success or failure callback
         function if they were specified.
         Note: Does not explicitly raise exceptions. Individual exceptions won't
         be thrown for each call that fails. The success and failure callback
         functions corresponding to a call should handle its success or failure.
+        Args:
+            include_headers (optional): determines whether to include headers with
+            the incoming responses or not. Not returning headers is more efficient
+            if you do not intend to make use of them. Default value of True.
         Returns:
             If some of the calls have failed, returns  a new FacebookAdsApiBatch
             object with those calls. Otherwise, returns None.
@@ -472,7 +476,7 @@ class FacebookAdsApiBatch(object):
             return None
         method = 'POST'
         path = tuple()
-        params = {'batch': self._batch}
+        params = {'batch': self._batch, 'include_headers': include_headers}
         files = {}
         for call_files in self._files:
             if call_files:

--- a/facebookads/test/integration.py
+++ b/facebookads/test/integration.py
@@ -805,11 +805,11 @@ class BatchTestCase(FacebookAdsTestCase):
         # Make sure the calls went into the batch, not executed directly
         self.assertEqual(len(batch), self.num_campaigns)
 
-    def execute_batch(self, batch, max_tries):
+    def execute_batch(self, batch, max_tries, **kwargs):
         # Avoid a flaky test by retrying the batch calls if needed
         for i in range(max_tries):
             if batch:
-                batch = batch.execute()
+                batch = batch.execute(**kwargs)
             else:
                 break
 
@@ -820,6 +820,15 @@ class BatchTestCase(FacebookAdsTestCase):
             campaign.remote_create(batch=batch)
         self.check_batch_size(batch)
         self.execute_batch(batch, self.num_campaigns)
+        self.check_ids(campaigns)
+
+    def test_batch_call_no_headers(self):
+        campaigns = self.create_campaigns()
+        batch = FacebookAdsTestCase.TEST_API.new_batch()
+        for campaign in campaigns:
+            campaign.remote_create(batch=batch)
+        self.check_batch_size(batch)
+        self.execute_batch(batch, self.num_campaigns, include_headers=False)
         self.check_ids(campaigns)
 
 


### PR DESCRIPTION
As documented here:
https://developers.facebook.com/docs/graph-api/making-multiple-requests

Specifying this parameter would provide a noticeable performance improvements in systems which make lots of API calls in batch.
