### PR TITLE
Fix for TypeError in ObjectParser

### DIFF
--- a/facebookads/adobjects/objectparser.py
+++ b/facebookads/adobjects/objectparser.py
@@ -58,17 +58,21 @@ class ObjectParser:
             return self._custom_parse_method(response, self._api)
 
         data = response
-        if 'data' in response and isinstance(response['data'], dict):
-            data = response['data']
-        elif 'images' in response:
-            _, data = data['images'].popitem()
-        if 'campaigns' in data:
-            _, data = data['campaigns'].popitem()
-        elif 'adsets' in data:
-            _, data = data['adsets'].popitem()
-        elif 'ads' in data:
-            _, data = data['ads'].popitem()
-        if 'success' in data:
+        if isinstance(response, dict):
+            if 'data' in response and isinstance(response['data'], dict):
+                data = response['data']
+            elif 'images' in response:
+                _, data = response['images'].popitem()
+
+        if isinstance(data, dict):
+            if 'campaigns' in data:
+                _, data = data['campaigns'].popitem()
+            elif 'adsets' in data:
+                _, data = data['adsets'].popitem()
+            elif 'ads' in data:
+                _, data = data['ads'].popitem()
+
+        if isinstance(data, dict) and 'success' in data:
             del data['success']
 
         if self._reuse_object is not None:


### PR DESCRIPTION
see https://github.com/facebook/facebook-python-ads-sdk/issues/250

There have been several issues related to `data` and `results` in `ObjectParser.parse_single()` being type string or list but containing one of the keys, which causes a TypeError. For example, 'my_images' would evaluate to True for `'images' in data` on line 63, but the following line `data = data['images']` doesn't make sense if it is a string.

This pull request would fix the issue by wrapping the if statements in a typecheck making sure `data` is a dict.
