### PR TITLE
Mvdb/batch retry transient

### DIFF
--- a/facebookads/adobjects/abstractcrudobject.py
+++ b/facebookads/adobjects/abstractcrudobject.py
@@ -222,6 +222,7 @@ class AbstractCrudObject(AbstractObject):
         params=None,
         success=None,
         api_version=None,
+        transient_error=None,
     ):
         """Creates the object by calling the API.
         Args:
@@ -236,6 +237,8 @@ class AbstractCrudObject(AbstractObject):
                 the FacebookResponse of this call if the call succeeded.
             failure (optional): A callback function which will be called with
                 the FacebookResponse of this call if the call failed.
+            transient_error (optional): A callback function which will be called with
+                the FacebookResponse of this call if the call failed with a transient error.
         Returns:
             self if not a batch call.
             the return value of batch.add if a batch call.
@@ -281,10 +284,15 @@ class AbstractCrudObject(AbstractObject):
                 if failure:
                     failure(response)
 
+            def callback_transient_error(response):
+                if transient_error:
+                    transient_error(response)
+
             return batch.add_request(
                 request=request,
                 success=callback_success,
                 failure=callback_failure,
+                transient_error=callback_transient_error,
             )
         else:
             response = request.execute()
@@ -301,6 +309,7 @@ class AbstractCrudObject(AbstractObject):
         params=None,
         success=None,
         api_version=None,
+        transient_error=None,
     ):
         """Reads the object by calling the API.
         Args:
@@ -316,6 +325,8 @@ class AbstractCrudObject(AbstractObject):
                 the FacebookResponse of this call if the call succeeded.
             failure (optional): A callback function which will be called with
                 the FacebookResponse of this call if the call failed.
+            transient_error (optional): A callback function which will be called with
+                the FacebookResponse of this call if the call failed with a transient error.
         Returns:
             self if not a batch call.
             the return value of batch.add if a batch call.
@@ -348,10 +359,15 @@ class AbstractCrudObject(AbstractObject):
                 if failure:
                     failure(response)
 
+            def callback_transient_error(response):
+                if transient_error:
+                    transient_error(response)
+
             batch_call = batch.add_request(
                 request=request,
                 success=callback_success,
                 failure=callback_failure,
+                transient_error=callback_transient_error,
             )
             return batch_call
         else:
@@ -366,6 +382,7 @@ class AbstractCrudObject(AbstractObject):
         params=None,
         success=None,
         api_version=None,
+        transient_error=None,
     ):
         """Updates the object by calling the API with only the changes recorded.
         Args:
@@ -380,6 +397,8 @@ class AbstractCrudObject(AbstractObject):
                 the FacebookResponse of this call if the call succeeded.
             failure (optional): A callback function which will be called with
                 the FacebookResponse of this call if the call failed.
+            transient_error (optional): A callback function which will be called with
+                the FacebookResponse of this call if the call failed with a transient error.
         Returns:
             self if not a batch call.
             the return value of batch.add if a batch call.
@@ -414,10 +433,15 @@ class AbstractCrudObject(AbstractObject):
                 if failure:
                     failure(response)
 
+            def callback_transient_error(response):
+                if transient_error:
+                    transient_error(response)
+
             batch_call = batch.add_request(
                 request=request,
                 success=callback_success,
                 failure=callback_failure,
+                transient_error=callback_transient_error,
             )
             return batch_call
         else:
@@ -433,6 +457,7 @@ class AbstractCrudObject(AbstractObject):
         params=None,
         success=None,
         api_version=None,
+        transient_error=None,
     ):
         """Deletes the object by calling the API with the DELETE http method.
         Args:
@@ -445,6 +470,8 @@ class AbstractCrudObject(AbstractObject):
                 the FacebookResponse of this call if the call succeeded.
             failure (optional): A callback function which will be called with
                 the FacebookResponse of this call if the call failed.
+            transient_error (optional): A callback function which will be called with
+                the FacebookResponse of this call if the call failed with a transient error.
         Returns:
             self if not a batch call.
             the return value of batch.add if a batch call.
@@ -470,10 +497,15 @@ class AbstractCrudObject(AbstractObject):
                 if failure:
                     failure(response)
 
+            def callback_transient_error(response):
+                if transient_error:
+                    transient_error(response)
+
             batch_call = batch.add_request(
                 request=request,
                 success=callback_success,
                 failure=callback_failure,
+                transient_error=callback_transient_error,
             )
             return batch_call
         else:
@@ -498,7 +530,8 @@ class AbstractCrudObject(AbstractObject):
         self,
         batch=None,
         failure=None,
-        success=None
+        success=None,
+        transient_error=None,
     ):
         if 'Status' not in dir(self) or 'archived' not in dir(self.Status):
             raise TypeError('Cannot archive object of type %s.'
@@ -511,6 +544,7 @@ class AbstractCrudObject(AbstractObject):
             batch=batch,
             failure=failure,
             success=success,
+            transient_error=transient_error,
         )
     # To avoid breaking change. Will be deprecated
     save = remote_save

--- a/facebookads/adobjects/helpers/adimagemixin.py
+++ b/facebookads/adobjects/helpers/adimagemixin.py
@@ -113,6 +113,7 @@ class AdImageMixin:
         params=None,
         success=None,
         api_version=None,
+        transient_error=None,
     ):
         """Uploads filename and creates the AdImage object from it.
         It has same arguments as AbstractCrudObject.remote_create except it
@@ -133,6 +134,7 @@ class AdImageMixin:
                 params=params,
                 success=success,
                 api_version=api_version,
+                transient_error=transient_error,
             )
         return return_val
 
@@ -148,6 +150,7 @@ class AdImageMixin:
         params=None,
         success=None,
         api_version=None,
+        transient_error=None,
     ):
         if self[self.__class__.Field.id]:
             _, image_hash = self[self.__class__.Field.id].split(':')

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -116,6 +116,17 @@ class FacebookResponse(object):
         """Returns boolean indicating if the call failed."""
         return not self.is_success()
 
+    def is_transient(self):
+        """Returns boolean indicating if the response failure is transient."""
+        if self.is_success():
+            return False
+
+        json_body = self.json()
+        try:
+            return json_body.get('error', {}).get('is_transient', False)
+        except AttributeError:  # not a dict, we don't know much
+            return False
+
     def error(self):
         """
         Returns a FacebookRequestError (located in the exceptions module) with

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -510,8 +510,9 @@ class FacebookAdsApiBatch(object):
                 http_status=response.get('code'),
                 call=self._batch[index],
             )
-            if inner_fb_response.is_success() and self._success_callbacks[index]:
-                self._success_callbacks[index](inner_fb_response)
+            if inner_fb_response.is_success():
+                if self._success_callbacks[index]:
+                    self._success_callbacks[index](inner_fb_response)
             else:
                 # retry transient errors
                 if inner_fb_response.is_transient():

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -500,25 +500,26 @@ class FacebookAdsApiBatch(object):
         retry_indices = []
 
         for index, response in enumerate(responses):
-            if response:
-                body = response.get('body')
-                code = response.get('code')
-                headers = response.get('headers')
-
-                inner_fb_response = FacebookResponse(
-                    body=body,
-                    headers=headers,
-                    http_status=code,
-                    call=self._batch[index],
-                )
-
-                if inner_fb_response.is_success():
-                    if self._success_callbacks[index]:
-                        self._success_callbacks[index](inner_fb_response)
-                elif self._failure_callbacks[index]:
-                    self._failure_callbacks[index](inner_fb_response)
-            else:
+            if not response:
                 retry_indices.append(index)
+                continue
+
+            inner_fb_response = FacebookResponse(
+                body=response.get('body'),
+                headers=response.get('headers'),
+                http_status=response.get('code'),
+                call=self._batch[index],
+            )
+            if inner_fb_response.is_success() and self._success_callbacks[index]:
+                self._success_callbacks[index](inner_fb_response)
+            else:
+                # retry transient errors
+                if inner_fb_response.is_transient():
+                    retry_indices.append(index)
+
+                # execute failure callbacks on error, even if transient
+                if self._failure_callbacks[index]:
+                    self._failure_callbacks[index](inner_fb_response)
 
         if retry_indices:
             new_batch = self.__class__(self._api)

--- a/facebookads/api.py
+++ b/facebookads/api.py
@@ -706,8 +706,8 @@ class FacebookRequest:
             else:
                 return response
 
-    def add_to_batch(self, batch, success=None, failure=None):
-        batch.add_request(self, success, failure)
+    def add_to_batch(self, batch, success=None, failure=None, transient_error=None):
+        batch.add_request(self, success, failure, transient_error)
 
     def _extract_value(self, value):
         if hasattr(value, 'export_all_data'):

--- a/facebookads/mixins.py
+++ b/facebookads/mixins.py
@@ -52,7 +52,8 @@ class CanArchive(object):
         self,
         batch=None,
         failure=None,
-        success=None
+        success=None,
+        transient_error=None,
     ):
         return self.remote_update(
             params={
@@ -61,6 +62,7 @@ class CanArchive(object):
             batch=batch,
             failure=failure,
             success=success,
+            transient_error=transient_error,
         )
 
     """
@@ -71,7 +73,8 @@ class CanArchive(object):
         self,
         batch=None,
         failure=None,
-        success=None
+        success=None,
+        transient_error=None,
     ):
         return self.remote_update(
             params={
@@ -80,6 +83,7 @@ class CanArchive(object):
             batch=batch,
             failure=failure,
             success=success,
+            transient_error=transient_error,
         )
 
 

--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -488,5 +488,28 @@ class FacebookResponseTestCase(unittest.TestCase):
         resp = api.FacebookResponse(body="Service Unavailable", http_status=200)
         self.assertFalse(resp.is_success())
 
+    def test_is_transient_success(self):
+        resp = api.FacebookResponse(http_status=200)
+        self.assertFalse(resp.is_transient())
+
+    def test_is_transient_body_not_json(self):
+        resp = api.FacebookResponse(http_status=400)
+        self.assertFalse(resp.is_transient())
+
+    def test_is_transient_not_transient(self):
+        resp = api.FacebookResponse(
+            http_status=400,
+            body=json.dumps({"error": {"is_transient": False}})
+        )
+        self.assertFalse(resp.is_transient())
+
+    def test_is_transient_ok(self):
+        resp = api.FacebookResponse(
+            http_status=400,
+            body=json.dumps({"error": {"is_transient": True}})
+        )
+        self.assertTrue(resp.is_transient())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -470,6 +470,59 @@ class FacebookAdsApiBatchTestCase(unittest.TestCase):
             'relative_url': 'some/path?'+'key=' + utils.urls.quote_with_encoding(u'vàlué')
         })
 
+    class FakeApi(object):
+        def __init__(self, body):
+            self.body = body
+
+        def call(self, method, path, params, files):
+            self.method, self.path, self.params, self.files = method, path, params, files
+            return api.FacebookResponse(http_status=200, body=json.dumps(self.body))
+
+    def test_execute_ok(self):
+        body = [
+            {"body": {}, "code": 200},
+        ]
+        fake_api = self.FakeApi(body)
+        batch = api.FacebookAdsApiBatch(fake_api)
+        batch.add("GET", "/endpoint", params={"key": "value"})
+        self.assertIsNone(batch.execute())
+        self.assertEqual(fake_api.method, 'POST')
+        self.assertEqual(fake_api.path, ())
+        self.assertEqual(fake_api.params, {"batch": [{'method': 'GET', 'relative_url': '/endpoint?key=value'}]})
+        self.assertEqual(fake_api.files, {})
+
+    def test_execute_transient(self):
+        body = [
+            {"body": {"error": {"is_transient": True}}, "code": 400},
+        ]
+        fake_api = self.FakeApi(body)
+        batch = api.FacebookAdsApiBatch(fake_api)
+        batch.add("GET", "/endpoint", params={"key": "value"})
+        new_batch = batch.execute()
+        self.assertIsNotNone(new_batch)
+        self.assertEqual(fake_api.method, 'POST')
+        self.assertEqual(fake_api.path, ())
+        self.assertEqual(fake_api.params, {"batch": [{'method': 'GET', 'relative_url': '/endpoint?key=value'}]})
+        self.assertEqual(fake_api.files, {})
+
+        self.assertEqual(len(new_batch), 1)  # one failure is transient
+
+    def test_execute_response_is_none(self):
+        body = [
+            None
+        ]
+        fake_api = self.FakeApi(body)
+        batch = api.FacebookAdsApiBatch(fake_api)
+        batch.add("GET", "/endpoint", params={"key": "value"})
+        new_batch = batch.execute()
+        self.assertIsNotNone(new_batch)
+        self.assertEqual(fake_api.method, 'POST')
+        self.assertEqual(fake_api.path, ())
+        self.assertEqual(fake_api.params, {"batch": [{'method': 'GET', 'relative_url': '/endpoint?key=value'}]})
+        self.assertEqual(fake_api.files, {})
+
+        self.assertEqual(len(new_batch), 1)  # one failure is transient
+
 
 class VersionUtilsTestCase(unittest.TestCase):
 

--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -484,12 +484,16 @@ class FacebookAdsApiBatchTestCase(unittest.TestCase):
         ]
         fake_api = self.FakeApi(body)
         batch = api.FacebookAdsApiBatch(fake_api)
-        batch.add("GET", "/endpoint", params={"key": "value"})
+        self.success_called = False
+        def callback(resp):
+            self.success_called = True
+        batch.add("GET", "/endpoint", params={"key": "value"}, success=callback)
         self.assertIsNone(batch.execute())
         self.assertEqual(fake_api.method, 'POST')
         self.assertEqual(fake_api.path, ())
         self.assertEqual(fake_api.params, {"batch": [{'method': 'GET', 'relative_url': '/endpoint?key=value'}]})
         self.assertEqual(fake_api.files, {})
+        self.assertTrue(self.success_called)
 
     def test_execute_transient(self):
         body = [
@@ -497,13 +501,17 @@ class FacebookAdsApiBatchTestCase(unittest.TestCase):
         ]
         fake_api = self.FakeApi(body)
         batch = api.FacebookAdsApiBatch(fake_api)
-        batch.add("GET", "/endpoint", params={"key": "value"})
+        self.failure_called = False
+        def callback(resp):
+            self.failure_called = True
+        batch.add("GET", "/endpoint", params={"key": "value"}, failure=callback)
         new_batch = batch.execute()
         self.assertIsNotNone(new_batch)
         self.assertEqual(fake_api.method, 'POST')
         self.assertEqual(fake_api.path, ())
         self.assertEqual(fake_api.params, {"batch": [{'method': 'GET', 'relative_url': '/endpoint?key=value'}]})
         self.assertEqual(fake_api.files, {})
+        self.assertTrue(self.failure_called)
 
         self.assertEqual(len(new_batch), 1)  # one failure is transient
 
@@ -513,13 +521,17 @@ class FacebookAdsApiBatchTestCase(unittest.TestCase):
         ]
         fake_api = self.FakeApi(body)
         batch = api.FacebookAdsApiBatch(fake_api)
-        batch.add("GET", "/endpoint", params={"key": "value"})
+        self.failure_called = False
+        def callback(resp):
+            self.failure_called = True
+        batch.add("GET", "/endpoint", params={"key": "value"}, failure=callback)
         new_batch = batch.execute()
         self.assertIsNotNone(new_batch)
         self.assertEqual(fake_api.method, 'POST')
         self.assertEqual(fake_api.path, ())
         self.assertEqual(fake_api.params, {"batch": [{'method': 'GET', 'relative_url': '/endpoint?key=value'}]})
         self.assertEqual(fake_api.files, {})
+        self.assertFalse(self.failure_called)
 
         self.assertEqual(len(new_batch), 1)  # one failure is transient
 


### PR DESCRIPTION
Hi there,

Here is a small PR to make it possible to retry transient errors during a batch call. It includes a nice shortcut to find out if a failure is transient (`FacebookResponse.is_transient()`) and everything is tested. We're gonna merge that on our fork, can you let me know if this is something that you're likely to merge, and if not, why it doesn't fit your needs?

On a side note, for testing under python 2.7, I would recommend using [`mock`](http://www.voidspace.org.uk/python/mock/) module as an optional requirement (maybe add a `dev_requirements.txt` file). I wanted to test the full `FacebookAdsApiBatch.execute()` method because it's rather critical but couldn't because of that. (we don't need it for python 3 because there is `unittest.mock`)

cc @daphyFB @JiamingFB 

Cheers!
