### PR TITLE
Fix AdReportRunMixin.__nonzero__ behaviour

### DIFF
--- a/facebookads/adobjects/helpers/adreportrunmixin.py
+++ b/facebookads/adobjects/helpers/adreportrunmixin.py
@@ -38,6 +38,8 @@ class AdReportRunMixin:
             self.get(self.Field.async_status) == 'Job Completed'
         )
 
+    __bool__ = __nonzero__  # py3
+
     def _setitem_trigger(self, key, value):
         if key == 'report_run_id':
             self._data['id'] = self['report_run_id']

--- a/facebookads/adobjects/helpers/adreportrunmixin.py
+++ b/facebookads/adobjects/helpers/adreportrunmixin.py
@@ -28,7 +28,15 @@ class AdReportRunMixin:
         return self.get_insights(params=params)
 
     def __nonzero__(self):
-        return self[self.Field.async_percent_completion] == 100
+        """
+        AdReportRunMixin evaluates to True if the report computation is over,
+        and False if not. There is an edge case when the computation is over
+        but marked as failed.
+        """
+        return (
+            self[self.Field.async_percent_completion] == 100 and
+            self.get(self.Field.async_status) == 'Job Completed'
+        )
 
     def _setitem_trigger(self, key, value):
         if key == 'report_run_id':

--- a/facebookads/test/unit.py
+++ b/facebookads/test/unit.py
@@ -39,6 +39,7 @@ from .. import specs
 from .. import exceptions
 from .. import session
 from .. import utils
+from facebookads.adobjects.adreportrun import AdReportRun
 from facebookads.utils import version
 
 
@@ -124,6 +125,31 @@ class CustomAudienceTestCase(unittest.TestCase):
 
         actual = payload['payload']['data']
         assert actual == expected
+
+
+class AdReportRunTestCase(unittest.TestCase):
+
+    def test_nonzero_not_over(self):
+        report = AdReportRun()
+        report[report.Field.async_percent_completion] = 76
+        self.assertFalse(report)
+
+    def test_nonzero_over_async_status_not_fetched(self):
+        report = AdReportRun()
+        report[report.Field.async_percent_completion] = 100
+        self.assertFalse(report)
+
+    def test_nonzero_over_failed(self):
+        report = AdReportRun()
+        report[report.Field.async_percent_completion] = 100
+        report[report.Field.async_status] = 'Job failed'
+        self.assertFalse(report)
+
+    def test_nonzero_ok(self):
+        report = AdReportRun()
+        report[report.Field.async_percent_completion] = 100
+        report[report.Field.async_status] = 'Job Completed'
+        self.assertTrue(report)
 
 
 class EdgeIteratorTestCase(unittest.TestCase):


### PR DESCRIPTION
fixes #149 

Reference: https://developers.facebook.com/docs/marketing-api/insights/async/v2.7

Hi @daphyFB  here is the fix for `AdReportRunMixin.__nonzero__`, compatible with 2.7.

Cheers :)
