### PR TITLE
Update API_VERSION to latest version

### DIFF
--- a/facebookads/apiconfig.py
+++ b/facebookads/apiconfig.py
@@ -19,7 +19,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 ads_api_config = {
-  'API_VERSION': 'v2.11',
+  'API_VERSION': 'v2.12',
   'SDK_VERSION': 'v2.11.3',
   'STRICT_MODE': False
 }


### PR DESCRIPTION
This update fix this error, after calls FacebookAdsApi:
(#2635) You are calling a deprecated version of the Ads API. Please update to
the latest version: v2.12