### PR TITLE
Decrease interval default

### DIFF
--- a/facebookads/adobjects/advideo.py
+++ b/facebookads/adobjects/advideo.py
@@ -70,7 +70,7 @@ class AdVideo(AbstractCrudObject):
         self._set_data(response)
         return response
 
-    def waitUntilEncodingReady(self, interval=30, timeout=600):
+    def waitUntilEncodingReady(self, interval=10, timeout=600):
         if 'id' not in self:
             raise FacebookError(
                 'Invalid Video ID',


### PR DESCRIPTION
The default of 30 seconds is many time. We had a problem with uwsgi because uwsgi close the conection because "detect a large sleep".