### PR TITLE
Fix api call v3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python: 2.7
 env:
   - TOX_ENV=py34
-  - TOX_ENV=py33
   - TOX_ENV=py27
 install:
   - pip install tox 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Facebook Business SDK for Python
 
-[![Build Status](https://travis-ci.org/facebook/facebook-python-business-sdk.svg)](https://travis-ci.org/facebook/facebook-python-business-sdk)
+[![Build Status](https://travis-ci.org/dpserretti/facebook-python-business-sdk.svg)](https://travis-ci.org/facebook/facebook-python-business-sdk)
 
 ### Introduction
 

--- a/facebook_business/api.py
+++ b/facebook_business/api.py
@@ -239,7 +239,7 @@ class FacebookAdsApi(object):
         headers=None,
         files=None,
         url_override=None,
-        api_version=None,
+        api_version="v3.1",
     ):
         """Makes an API call.
         Args:

--- a/facebook_business/test/unit.py
+++ b/facebook_business/test/unit.py
@@ -501,5 +501,6 @@ class FacebookResponseTestCase(unittest.TestCase):
         resp = api.FacebookResponse(body="Service Unavailable", http_status=200)
         self.assertFalse(resp.is_success())
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ readme_filename = os.path.join(this_dir, 'README.md')
 requirements_filename = os.path.join(this_dir, 'requirements.txt')
 
 PACKAGE_NAME = 'facebook_business'
-PACKAGE_VERSION = '3.1.2'
+PACKAGE_VERSION = '3.1.3'
 PACKAGE_AUTHOR = 'Facebook'
 PACKAGE_AUTHOR_EMAIL = ''
 PACKAGE_URL = 'https://github.com/facebook/facebook-python-business-sdk'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py33,py34
+envlist = py27,py34
 
 [testenv]
 commands =


### PR DESCRIPTION
- Ajusted api calls to communicate with api v3.1, acordding to the following link https://developers.facebook.com/docs/graph-api/changelog#versions 
- Removed TOX_ENV for python 3.3 (py33). It was breaking the build from Travis.
