### PR TITLE
Fixed NameError in AbstractObject.__eq__

### DIFF
--- a/facebook_business/adobjects/abstractobject.py
+++ b/facebook_business/adobjects/abstractobject.py
@@ -55,7 +55,7 @@ class AbstractObject(collections.MutableMapping):
         return self
 
     def __eq__(self, other):
-        return other is not None and hasattr(targeting, 'export_all_data') and \
+        return other is not None and hasattr(other, 'export_all_data') and \
             self.export_all_data() == other.export_all_data()
 
     def __delitem__(self, key):


### PR DESCRIPTION
Fixes same issue as in https://github.com/facebook/facebook-python-business-sdk/pull/520, but only changes affected code.

Note that tests are failing because python 3.3 isn't in your Travis environment. (the other PR removes the 3.3 tox envs in addition to this fix)