### PR TITLE
Add success and failure callbacks to get_insights call

### DIFF
--- a/facebook_business/adobjects/adaccount.py
+++ b/facebook_business/adobjects/adaccount.py
@@ -3180,10 +3180,11 @@ class AdAccount(
             self.assure_call()
             return request.execute()
 
-    def get_insights(self, fields=None, params=None, is_async=False, batch=None, pending=False):
+    def get_insights(self, fields=None, params=None, is_async=False, batch=None, success=None, failure=None,
+                     pending=False):
         from facebook_business.adobjects.adsinsights import AdsInsights
         if is_async:
-          return self.get_insights_async(fields, params, batch, pending)
+            return self.get_insights_async(fields, params, batch, success, failure, pending)
         param_types = {
             'default_summary': 'bool',
             'fields': 'list<string>',
@@ -3230,7 +3231,7 @@ class AdAccount(
         request.add_fields(fields)
 
         if batch is not None:
-            request.add_to_batch(batch)
+            request.add_to_batch(batch, success=success, failure=failure)
             return request
         elif pending:
             return request
@@ -3238,7 +3239,7 @@ class AdAccount(
             self.assure_call()
             return request.execute()
 
-    def get_insights_async(self, fields=None, params=None, batch=None, pending=False):
+    def get_insights_async(self, fields=None, params=None, batch=None, success=None, failure=None, pending=False):
         from facebook_business.adobjects.adreportrun import AdReportRun
         from facebook_business.adobjects.adsinsights import AdsInsights
         param_types = {
@@ -3287,7 +3288,7 @@ class AdAccount(
         request.add_fields(fields)
 
         if batch is not None:
-            request.add_to_batch(batch)
+            request.add_to_batch(batch, success=success, failure=failure)
             return request
         elif pending:
             return request


### PR DESCRIPTION
**Important note: I know that the changes I propose are made in an auto-generated class; I just need these changes to be done in the automated way there is and then just discard my pull request.**

The `get_insights` call doesn't allow receiving success and failure callbacks for the batch process, and therefore I cannot batch these calls and get all the data as it is done in this example, line 140, for creating ads: https://github.com/facebook/facebook-python-business-sdk/blob/master/examples/ad_creation_utils.py

As you may know, the batch object is already prepared to receive several callbacks in the `request.add_to_batch` call, so I'm not really proposing a change on your inner features but just having this feature in the `get_insights` method.

In case this is feature is not intended to be used this way and, therefore, the changes make no sense, I'd like to know how should I add these callbacks -or, otherwise, how should I manage all the Facebook responses in just one callback.