### PR TITLE
Added per-Cursor headers support.

### DIFF
--- a/facebook_business/api.py
+++ b/facebook_business/api.py
@@ -750,6 +750,7 @@ class Cursor(object):
             self._endpoint,
         )
         self._queue = []
+        self._headers = []
         self._finished_iteration = False
         self._total_count = None
         self._summary = None
@@ -781,6 +782,9 @@ class Cursor(object):
 
     def __getitem__(self, index):
         return self._queue[index]
+
+    def headers(self):
+        return self._headers
 
     def total(self):
         if self._total_count is None:
@@ -820,11 +824,13 @@ class Cursor(object):
         ):
             self.params['summary'] = True
 
-        response = self._api.call(
+        response_obj = self._api.call(
             'GET',
             self._path,
             params=self.params,
-        ).json()
+        )
+        response = response_obj.json()
+        self._headers = response_obj.headers()
 
         if 'paging' in response and 'next' in response['paging']:
             self._path = response['paging']['next']


### PR DESCRIPTION
Main intent for this PR is to give visibility into per-request headers. With this change API users can monitor X-FB-Ads-Insights-Throttle and  X-Ad-Account-Usage headers themselves and introduce sleeps in their code if needed.