### PR TITLE
get_insights_async: AdReportRun to AdsInsights

### DIFF
--- a/facebook_business/adobjects/adaccount.py
+++ b/facebook_business/adobjects/adaccount.py
@@ -3172,9 +3172,9 @@ class AdAccount(
             endpoint='/insights',
             api=self._api,
             param_checker=TypeChecker(param_types, enums),
-            target_class=AdReportRun,
+            target_class=AdsInsights,
             api_type='EDGE',
-            response_parser=ObjectParser(target_class=AdReportRun, api=self._api),
+            response_parser=ObjectParser(target_class=AdsInsights, api=self._api),
             include_summary=False,
         )
         request.add_params(params)


### PR DESCRIPTION
get_insights_async raises many warnings about FIELD, because of the differences between fields of AdReportRun and AdsInsights.