### PR TITLE
Fix normalize_key to return appuid properly

### DIFF
--- a/facebook_business/adobjects/helpers/customaudiencemixin.py
+++ b/facebook_business/adobjects/helpers/customaudiencemixin.py
@@ -140,7 +140,8 @@ class CustomAudienceMixin:
 
         if(key_name == cls.Schema.MultiKeySchema.extern_id or
            key_name == cls.Schema.MultiKeySchema.email or
-           key_name == cls.Schema.MultiKeySchema.madid):
+           key_name == cls.Schema.MultiKeySchema.madid or
+           key_name == cls.Schema.MultiKeySchema.appuid):
             return key_value
 
         if(key_name == cls.Schema.MultiKeySchema.phone):

--- a/facebook_business/test/unit.py
+++ b/facebook_business/test/unit.py
@@ -44,7 +44,7 @@ from facebook_business.adobjects import (abstractcrudobject,
                                    adcreative,
                                    customaudience,
                                    productcatalog,
-                                   reachestimate)
+                                   adaccountreachestimate)
 from facebook_business.utils import version
 
 

--- a/facebook_business/test/unit.py
+++ b/facebook_business/test/unit.py
@@ -200,7 +200,7 @@ class EdgeIteratorTestCase(unittest.TestCase):
     def test_builds_from_object_with_data_key(self):
         """
         Sometimes the response returns a single JSON object - with a "data".
-        For instance with reachestimate. This asserts that we successfully
+        For instance with adaccountreachestimate. This asserts that we successfully
         build the object that is in "data" key.
         """
         response = {
@@ -223,7 +223,7 @@ class EdgeIteratorTestCase(unittest.TestCase):
         }
         ei = api.Cursor(
             ad.Ad('123'),
-            reachestimate.ReachEstimate,
+            adaccountreachestimate.AdAccountReachEstimate,
         )
         obj = ei.build_objects_from_response(response)
         assert len(obj) == 1 and obj[0]['users'] == 7600000


### PR DESCRIPTION
```
                    for key in user:
                        key = key.strip(" \t\r\n\0\x0B.").lower()
                        key = cls.normalize_key(schema[counter],
                                                           str(key))
                        if schema[counter] != \
                                cls.Schema.MultiKeySchema.extern_id:
                            if isinstance(key, six.text_type):
                                key = key.encode('utf8')
                            key = hashlib.sha256(key).hexdigest()
```

In `format_params`, when a key's schema is Schema.MultiKeySchema.appuid, it will enter `normalize_key` function and return None. Thus, causing an error when you are trying to hash. Therefore, I propose to change the `normalize_key` function to return key_value when key's schema is Schema.MultiKeySchema.appuid