### PR TITLE
Detect all HTTP errors in FacebookResponse

### DIFF
--- a/facebook_business/api.py
+++ b/facebook_business/api.py
@@ -91,6 +91,10 @@ class FacebookResponse(object):
     def is_success(self):
         """Returns boolean indicating if the call was successful."""
 
+        if 400 <= self._http_status < 600:
+            # Any HTTP error
+            return False
+
         json_body = self.json()
 
         if isinstance(json_body, collections.Mapping) and 'error' in json_body:


### PR DESCRIPTION
With the current implementation, any error response with a non-empty body will be considered a success unless it contains the string "Service Unavailable". This includes, for example, a 502 Bad Gateway response with an HTML body, causing other code to consider the call a success and fail when trying to treat the HTML response as a dict.

This change makes sure HTTP errors are never considered successful requests.