### PR TITLE
Fix get_job_async()

### DIFF
--- a/facebook_business/adobjects/ad.py
+++ b/facebook_business/adobjects/ad.py
@@ -595,7 +595,7 @@ class Ad(
 
         if fields is not None:
             params['fields'] = params.get('fields') if params.get('fields') is not None else list()
-            params['fields'].extend(fields)
+            params['fields'].extend(field for field in fields if field not in params['fields'])
 
         request = FacebookRequest(
             node_id=self['id'],

--- a/facebook_business/adobjects/adaccount.py
+++ b/facebook_business/adobjects/adaccount.py
@@ -3305,7 +3305,7 @@ class AdAccount(
 
         if fields is not None:
             params['fields'] = params.get('fields') if params.get('fields') is not None else list()
-            params['fields'].extend(fields)
+            params['fields'].extend(field for field in fields if field not in params['fields'])
 
         request = FacebookRequest(
             node_id=self['id'],

--- a/facebook_business/adobjects/adset.py
+++ b/facebook_business/adobjects/adset.py
@@ -931,7 +931,7 @@ class AdSet(
 
         if fields is not None:
             params['fields'] = params.get('fields') if params.get('fields') is not None else list()
-            params['fields'].extend(fields)
+            params['fields'].extend(field for field in fields if field not in params['fields'])
 
         request = FacebookRequest(
             node_id=self['id'],

--- a/facebook_business/adobjects/campaign.py
+++ b/facebook_business/adobjects/campaign.py
@@ -728,7 +728,7 @@ class Campaign(
 
         if fields is not None:
             params['fields'] = params.get('fields') if params.get('fields') is not None else list()
-            params['fields'].extend(fields)
+            params['fields'].extend(field for field in fields if field not in params['fields'])
 
         request = FacebookRequest(
             node_id=self['id'],


### PR DESCRIPTION
Summary:
This diff is associated with the PR: https://github.com/facebook/facebook-python-business-sdk/pull/554

In case of developers assign value of the fields both in `params['fields']` and `fields`, I just removed the duplicated value in `params['fields']` when we move the `fields` to `params['fields']` for `get_job_async()` call.

Reviewed By: Mxiim

Differential Revision: D19426200

