### PR TITLE
Make curl debug output more user friendly

### DIFF
--- a/facebook_business/api.py
+++ b/facebook_business/api.py
@@ -326,7 +326,11 @@ class FacebookAdsApi(object):
             )
         if self._enable_debug_logger:
             import curlify
-            print(curlify.to_curl(response.request))
+            import copy
+            request = copy.deepcopy(response.request)
+            request.headers['Accept'] = 'application/json'
+            del request.headers['Accept-Encoding']
+            print(curlify.to_curl(request))
         fb_response = FacebookResponse(
             body=response.text,
             headers=response.headers,


### PR DESCRIPTION
The curl output helps when debugging requests made to the FB API.

However it's not as user friendly as it should be because it retrieves
gzipped content which can't immediately be displayed when running the
curl command in the terminal. See the below post by the curl maintainer
on why binary output is no longer displayed in stdout by default.

https://daniel.haxx.se/blog/2017/06/17/curl-doesnt-spew-binary-anymore/

Instead of displaying binary output I force the API to return
uncompressed JSON which can immediately be displayed when running the
command. See the below two examples.

Without this patch:
```
$ curl -X GET -H 'Accept: application/json' -H 'Accept-Encoding: gzip, deflate' -H 'Connection: keep-alive' -H 'User-Agent: fbbizsdk-python-v5.0.1' 'https://graph.facebook.com/v5.0/me/adaccounts?access_token=xxxxxx&summary=true'
Warning: Binary output can mess up your terminal. Use "--output -" to tell
Warning: curl to output it to your terminal anyway, or consider "--output
Warning: <FILE>" to save to a file.
```

With this patch:
```
$ curl -X GET -H 'Accept: application/json' -H 'Connection: keep-alive' -H 'User-Agent: fbbizsdk-python-v5.0.1' 'https://graph.facebook.com/v5.0/me/adaccounts?access_token=xxxxxx&summary=true'
{"data":[{"account_id":"abc","id":"act_abc"},"summary":{"total_count":1}}
```