### PR TITLE
bugfix: error_data statement when null

### DIFF
--- a/facebook_business/exceptions.py
+++ b/facebook_business/exceptions.py
@@ -80,7 +80,7 @@ class FacebookRequestError(FacebookError):
                 self._api_error_subcode = self._error['error_subcode']
             if 'type' in self._error:
                 self._api_error_type = self._error['type']
-            if error_data.get('blame_field_specs'):
+            if error_data and error_data.get('blame_field_specs'):
                 self._api_blame_field_specs = \
                     self._error['error_data']['blame_field_specs']
         else:


### PR DESCRIPTION
I've got an error during request to create adset. The error reason doesn't match with pull request changes but there is another problem.
1. `'error_data': 'null',`
2. `json.loads('null')` returns NoneType object
3. `error_data.get('blame_field_specs')` throws an exception `AttributeError: 'NoneType' object has no attribute 'get'`
```
{
'message': 'Invalid parameter', 
'type': 'OAuthException', 
'code': 100, 
'error_data': 'null', 
'error_subcode': 1487079, 
'is_transient': False, 
'error_user_title': 'Invalid targeting spec', 
'error_user_msg': 'The specified targeting spec is not valid because: The field audience_positions is not a valid target spec field', 
'fbtrace_id': 'Ai7361tVWYjx2dvScd15MG9'
}
```