### PR TITLE
Only install enum34 in python < 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ six >= 1.7.3
 curlify >= 2.1.0
 pycountry >= 19.8.18
 mock >= 1.0.1
-enum34
+enum34; python_version < '3.4'


### PR DESCRIPTION
Hi guys,

I am running into a problem where installing this sdk in a python version above 3.3 results in the following error:

```shell
    ERROR: Command errored out with exit status 1:
     command: /home/********/project/.venv/bin/python /home/********/project/.venv/lib/python3.7/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-zy0jipsb/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel
         cwd: None
    Complete output (14 lines):
    Traceback (most recent call last):
      File "/usr/local/lib/python3.7/runpy.py", line 193, in _run_module_as_main
        "__main__", mod_spec)
      File "/usr/local/lib/python3.7/runpy.py", line 85, in _run_code
        exec(code, run_globals)
      File "/home/********/project/.venv/lib/python3.7/site-packages/pip/__main__.py", line 23, in <module>
        from pip._internal.cli.main import main as _main  # isort:skip # noqa
      File "/home/********/project/.venv/lib/python3.7/site-packages/pip/_internal/cli/main.py", line 5, in <module>
        import locale
      File "/home/********/project/.venv/lib/python3.7/locale.py", line 16, in <module>
        import re
      File "/home/********/project/.venv/lib/python3.7/re.py", line 143, in <module>
        class RegexFlag(enum.IntFlag):
    AttributeError: module 'enum' has no attribute 'IntFlag'
    ----------------------------------------
  ERROR: Command errored out with exit status 1: /home/********/project/.venv/bin/python /home/********/project/.venv/lib/python3.7/site-packages/pip install --ignore-installed --no-user --prefix /tmp/pip-build-env-zy0jipsb/overlay --no-warn-script-location --no-binary :none: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.8.0' wheel Check the logs for full command output.
```

This is because facebook-python-business-sdk requires you to install enum34 regardless of your python version.

enum34 is a package that override the `enum` namespace in the python standard library in python versions 3.4 and above. This package has a slightly different api from the standard library version and if your code or the code in any of your other dependencies calls on enum, it can trigger a traceback like above.

It is a necessary package for python versions below 3.4 since enums did not exist in those versions.

This PR should alleviate this issue.