### PR TITLE
Fix error when error_data is a string

### DIFF
--- a/facebook_business/exceptions.py
+++ b/facebook_business/exceptions.py
@@ -80,7 +80,7 @@ class FacebookRequestError(FacebookError):
                 self._api_error_subcode = self._error['error_subcode']
             if 'type' in self._error:
                 self._api_error_type = self._error['type']
-            if error_data and error_data.get('blame_field_specs'):
+            if error_data and isinstance(error_data, dict) and error_data.get('blame_field_specs'):
                 self._api_blame_field_specs = \
                     error_data['blame_field_specs']
         else:


### PR DESCRIPTION
Fix exception when parsing FB error
Original exception, which causes problem:
{
"message":"Invalid parameter",
"type":"OAuthException",
"code":100,
**"error_data":"\\"null\\""**,
"error_subcode":1815629,
"is_transient":false,
"error_user_title":"Duplicates of ad asset values are not allowed",
"error_user_msg":"All ad asset values should be unique. Please check your values.(Duplicate value: 3)",
"fbtrace_id":"A1sergAuftAtWjA8BctXnzy"
}