### PR TITLE
Do not install test requirements in distribution

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,2 @@
+enum34; python_version < '3.4'
+mock >= 1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,4 @@ requests >= 2.3.0
 six >= 1.7.3
 curlify >= 2.1.0
 pycountry >= 19.8.18
-mock >= 1.0.1
-enum34; python_version < '3.4'
 aiohttp; python_version >= '3.5.3'

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,6 @@ envlist = py27,py33,py34,py35,py36,py37
 commands =
     {envpython} -m facebook_business.test.unit
     {envpython} -m facebook_business.test.integration_test_runner
-deps = -rrequirements.txt
+deps =
+    -rrequirements.txt
+    -rrequirements-tests.txt


### PR DESCRIPTION
Installing facebook-python-business-sdk from PyPI installs mock, a development requirement.
This PR only installs development requirements when running tests.