### PR TITLE
Relaxing requirement of a  strict float-type to less restrictive float-castable

### DIFF
--- a/facebook_business/adobjects/serverside/custom_data.py
+++ b/facebook_business/adobjects/serverside/custom_data.py
@@ -25,6 +25,7 @@ from facebook_business.adobjects.serverside.content import Content
 from facebook_business.adobjects.serverside.normalize import Normalize
 from facebook_business.adobjects.serverside.delivery_category import DeliveryCategory
 
+
 class CustomData(object):
     """
     CustomData includes additional business data about the event.

--- a/facebook_business/adobjects/serverside/custom_data.py
+++ b/facebook_business/adobjects/serverside/custom_data.py
@@ -138,8 +138,8 @@ class CustomData(object):
             raise TypeError('CustomData.value must be a float value')
         self._value = casted_value
 
-    def safecast_to_float(self, value, value_description=None):
-        """Returns the float equivalent of a the passed value_description. If casting fails, returns None.
+    def safecast_to_float(self, value):
+        """Returns value casted to float, if casting fails, returns None.
         
         Due to discrepancy between Javasctipt's JSON.stringify() in JS vs Pythonic json.dumps()
         it is needed to perform casting some numbers (integer) back to float to match type requirements.

--- a/facebook_business/adobjects/serverside/custom_data.py
+++ b/facebook_business/adobjects/serverside/custom_data.py
@@ -133,9 +133,31 @@ class CustomData(object):
         :param value: The value.
         :type: float
         """
-        if not isinstance(value, float):
+        casted_value = self.safecast_to_float(value)
+        if not isinstance(casted_value, float):
             raise TypeError('CustomData.value must be a float value')
-        self._value = value
+        self._value = casted_value
+
+    def safecast_to_float(self, value, value_description=None):
+        """Returns the float equivalent of a the passed value_description. If casting fails, returns None.
+        
+        Due to discrepancy between Javasctipt's JSON.stringify() in JS vs Pythonic json.dumps()
+        it is needed to perform casting some numbers (integer) back to float to match type requirements.
+
+        In JS:
+        JSON.parse(JSON.stringify({value: 100.0}))
+        > {value: 100}
+
+        In Python:
+        json.loads(json.dumps({"val": 100.0}))                                                                         
+        > {'val': 100.0}
+
+        :param value: The value that is castable to float.
+        """
+        try:
+            return float(value)
+        except ValueError:
+            None
 
     @property
     def currency(self):
@@ -326,9 +348,10 @@ class CustomData(object):
         :param predicted_ltv: The predicted_ltv.
         :type: float
         """
-        if not isinstance(predicted_ltv, float):
+        casted_predicted_ltv = self.safecast_to_float(predicted_ltv)
+        if not isinstance(casted_predicted_ltv, float):
             raise TypeError('CustomData.predicted_ltv must be a float value')
-        self._predicted_ltv = predicted_ltv
+        self._predicted_ltv = casted_predicted_ltv
 
     @property
     def num_items(self):

--- a/facebook_business/adobjects/serverside/custom_data.py
+++ b/facebook_business/adobjects/serverside/custom_data.py
@@ -138,24 +138,24 @@ class CustomData(object):
             raise TypeError('CustomData.value must be a float value')
         self._value = casted_value
 
-    def safecast_to_float(self, value):
-        """Returns value casted to float, if casting fails, returns None.
+    def safecast_to_float(self, input):
+        """Returns input casted to float, if casting fails, returns None.
         
         Due to discrepancy between Javasctipt's JSON.stringify() in JS vs Pythonic json.dumps()
         it is needed to perform casting some numbers (integer) back to float to match type requirements.
 
         In JS:
-        JSON.parse(JSON.stringify({value: 100.0}))
-        > {value: 100}
+        JSON.parse(JSON.stringify({val: 100.0}))
+        > {val: 100}
 
         In Python:
         json.loads(json.dumps({"val": 100.0}))                                                                         
         > {'val': 100.0}
 
-        :param value: The value that is castable to float.
+        :param input: The number that should be castable to float.
         """
         try:
-            return float(value)
+            return float(input)
         except ValueError:
             None
 

--- a/facebook_business/adobjects/serverside/tests/custom_data_test.py
+++ b/facebook_business/adobjects/serverside/tests/custom_data_test.py
@@ -24,7 +24,6 @@ from facebook_business.adobjects.serverside.content import Content
 from facebook_business.adobjects.serverside.custom_data import CustomData
 from facebook_business.adobjects.serverside.delivery_category import DeliveryCategory
 
-
 class CustomDataTest(TestCase):
     def test_normalize(self):
         content = Content(product_id='id0', quantity='quantity1', item_price=3.99)
@@ -92,3 +91,42 @@ class CustomDataTest(TestCase):
         custom_data = CustomData()
 
         self.assertEqual(custom_data.normalize(), {})
+
+class CustomDataFloatCastingTest(TestCase):
+    def test_safecasting_to_float_ok__100(self):
+        tested_value = 100  # Should be casted to expected 100.0
+        expected_value = 100.0 
+        tested_keys = ['value', 'predicted_ltv']
+
+        tested_kwargs = {}
+        for key in tested_keys:
+            tested_kwargs[key] = tested_value
+
+        custom_data = CustomData(**tested_kwargs)
+
+        # Verify just the tested keys
+        for key in tested_keys:
+            self.assertEqual(getattr(custom_data, key), expected_value)
+
+    def test_safecasting_to_float_ok__100_1(self):
+        tested_value = 100.1  # Should be casted to expected 100.0
+        expected_value = 100.1 
+        tested_keys = ['value', 'predicted_ltv']
+
+        tested_kwargs = {}
+        for key in tested_keys:
+            tested_kwargs[key] = tested_value
+
+        custom_data = CustomData(**tested_kwargs)
+
+        # Verify just the tested keys
+        for key in tested_keys:
+            self.assertEqual(getattr(custom_data, key), expected_value)
+
+    def test_safecasting_to_float__raises__value(self):
+        with self.assertRaises(TypeError):
+            CustomData(value="non-castable-value")
+
+    def test_safecasting_to_float__raises__predicted_ltv(self):
+        with self.assertRaises(TypeError):
+            CustomData(predicted_ltv="non-castable-value")


### PR DESCRIPTION
There is a mismatch in behaviour in generating JSON from JS objects and Python dictionaries.

In Javascript
```
JSON.parse(JSON.stringify({val: 100.0}))
out> {val: 100}
```

In Python:
```
json.loads(json.dumps({"val": 100.0}))                                                                         
out> {'val': 100.0}
```

This leads to problems when validating CustomData(), it seems like it should accept integers and cast them to floats if FB API really needs it.