### PR TITLE
Fix hashing for User Data payload

### DIFF
--- a/facebook_business/adobjects/serverside/user_data.py
+++ b/facebook_business/adobjects/serverside/user_data.py
@@ -762,8 +762,19 @@ class UserData(object):
         return normalized_payload
 
     def hash_sha_256(self, input):
+        """Returns the sha256 hash of the input.
+
+        In case the input is already hashed, it doesn't rehash it.
+
+        :param input
+        :type: str
+        """
         if input is None:
             return None
+
+        if Normalize.is_already_hashed(input):
+            return input
+
         input = input.encode('utf-8')
         return hashlib.sha256(input).hexdigest()
 


### PR DESCRIPTION
Currently, in the nomalize process, we do hash event the already hashed values. This makes it impossible to do testing from local servers. There are a lot of bugs being reported on suuport becuase of this.

The only way to be able to test it to use the hashed email provided by Payload Helper. But the current flow of normalization rehashes the hashed value.

This PR will test if the value is already hashed and will not try to re-hash it.