### PR TITLE
Error when event pushes

### DIFF
--- a/examples/AdsPixelEventsPost.py
+++ b/examples/AdsPixelEventsPost.py
@@ -30,7 +30,7 @@ FacebookAdsApi.init(access_token=access_token)
 fields = [
 ]
 params = {
-  'data': [{'event_name':'PageView','event_time':1614195236,'user_data':{'fbc':'fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890','fbp':'fb.1.1558571054389.1098115397','em':'309a0a5c3e211326ae75ca18196d301a9bdbd1a882a4d2569511033da23f0abd'}}],
+  'upload_tag':'page_view','data': [{'event_name':'PageView','event_time':1614195236,'user_data':{'fbc':'fb.1.1554763741205.AbCdEfGhIjKlMnOpQrStUvWxYz1234567890','fbp':'fb.1.1558571054389.1098115397','em':'309a0a5c3e211326ae75ca18196d301a9bdbd1a882a4d2569511033da23f0abd'}}],
 }
 print AdsPixel(id).create_event(
   fields=fields,


### PR DESCRIPTION
Facebook API does not accept an event without the "upload_tag" or "upload_id" so I changed the example to reflect that.  I do however still get a warning saying "data might not be compatible.  Expect list<string>; got <class 'list'>".   I am not sure what this error is or if it is hindering the API from accepting the event.