### PR TITLE
Update method used in `CustomAudienceDelete` example

### DIFF
--- a/examples/CustomAudienceDelete.py
+++ b/examples/CustomAudienceDelete.py
@@ -32,7 +32,7 @@ fields = [
 ]
 params = {
 }
-print CustomAudience(id).delete(
+print CustomAudience(id).api_delete(
   fields=fields,
   params=params,
 )


### PR DESCRIPTION
Using `delete` fails with

```
AttributeError: 'CustomAudience' object has no attribute 'delete'
```

The correct method would be `api_delete`