### PR TITLE
Fix lookalike_spec type

### DIFF
--- a/facebook_business/adobjects/adaccount.py
+++ b/facebook_business/adobjects/adaccount.py
@@ -2367,7 +2367,7 @@ class AdAccount(
             'is_snapshot': 'bool',
             'is_value_based': 'bool',
             'list_of_accounts': 'list<unsigned int>',
-            'lookalike_spec': 'string',
+            'lookalike_spec': 'map',
             'name': 'string',
             'opt_out_link': 'string',
             'origin_audience_id': 'string',


### PR DESCRIPTION
Currently, the `lookalike_spec` has a type of `string`, which will give the following warning.

```
UserWarning: value of lookalike_spec might not be compatible.  Expect string;  got <class 'dict'>
    warnings.warn(message)
```

However, this is incorrect. The documentation says `lookalike_spec` is a type `type: array`, which means it's a dictionary in Python. Changing `string` to `map` dismisses the warning.
