### PR TITLE
Update ad.py

### DIFF
--- a/facebook_business/adobjects/ad.py
+++ b/facebook_business/adobjects/ad.py
@@ -48,6 +48,7 @@ class Ad(
         adlabels = 'adlabels'
         adset = 'adset'
         adset_id = 'adset_id'
+        ad_active_time = 'ad_active_time'
         bid_amount = 'bid_amount'
         bid_info = 'bid_info'
         bid_type = 'bid_type'
@@ -713,6 +714,7 @@ class Ad(
         'adlabels': 'list<AdLabel>',
         'adset': 'AdSet',
         'adset_id': 'string',
+        'ad_active_time','string',
         'bid_amount': 'int',
         'bid_info': 'map<string, unsigned int>',
         'bid_type': 'BidType',


### PR DESCRIPTION
As shown on this [link](https://developers.facebook.com/docs/marketing-api/reference/adgroup#:~:text=ad%20belongs%20to.-,ad_active_time,-numeric%20string) we need to add ad_active time.