### PR TITLE
Updated typechecker.py to handle <list<map<string, string>>> correctly

### DIFF
--- a/facebook_business/typechecker.py
+++ b/facebook_business/typechecker.py
@@ -101,8 +101,12 @@ class TypeChecker:
             if not isinstance(value, dict):
                 return False
             sub_types = self.get_type_from_collection(value_type, 'map')
-            sub_type_key = sub_types[0]
-            sub_type_value = sub_types[1]
+            if len(sub_types) == 2:
+                sub_type_key = sub_types[0]
+                sub_type_value = sub_types[1]
+            else:
+                sub_type_key = 'string'
+                sub_type_value = sub_types[0]
             return all(self.is_type(sub_type_key, k) and
                 self.is_type(sub_type_value, v) for k, v in value.items())
 


### PR DESCRIPTION
Fixed issue with not parsing <list<map correctly.

I first noticed this when getting products underneath a product catalog. One of the items in the request consisted of a <list<list<map<string, string>>> value_type. This is currently not handled when this is parsed in the existing code. In the existing code, sub_type_value tries to access an index of the subtypes list that does not exist. I noticed some similar code in the function get_typed_value which I've used in the fix.