### PR TITLE
removed enum34 on newer python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ requests >= 2.3.0
 six >= 1.7.3
 curlify >= 2.1.0
 pycountry >= 19.8.18
-enum34; python_version >= '3'
+enum34; python_version < '3.4'
 aiohttp; python_version >= '3.5.3'


### PR DESCRIPTION
Same issue as #566 