### PR TITLE
Added python_requires argument for python version requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,4 +70,5 @@ setup(
     long_description=PACKAGE_LONG_DESCRIPTION,
     install_requires=PACKAGE_INSTALL_REQUIRES,
     long_description_content_type="text/markdown",
+    python_requires='>=3.7',
 )


### PR DESCRIPTION
python_requires argument in the setup function specifies the versions of python that package is compatible with like great than 3.7 or any which is required