### PR TITLE
Fix print statement syntax in UserLeadGenInfoNode.py

### DIFF
--- a/examples/UserLeadGenInfoNode.py
+++ b/examples/UserLeadGenInfoNode.py
@@ -17,7 +17,7 @@ fields = [
 ]
 params = {
 }
-print Lead(id).get(
+print(Lead(id).get(
   fields=fields,
   params=params,
-)
+))


### PR DESCRIPTION
Since "print" is now a function, parentheses have been added.