### PR TITLE
Fix FacebookResponse.is_success to properly handle API returns in csv format

### DIFF
--- a/facebook_business/api.py
+++ b/facebook_business/api.py
@@ -85,12 +85,13 @@ class FacebookResponse(object):
 
         json_body = self.json()
 
-        if isinstance(json_body, collections_abc.Mapping) and 'error' in json_body:
-            # Is a dictionary, has error in it
-            return False
-        elif bool(json_body):
-            # Has body and no error
+        if bool(json_body) and isinstance(json_body, collections_abc.Mapping):
+            # Is a dictionary
+            if 'error' in json_body:
+                # Has 'error' as a key
+                return False
             if 'success' in json_body:
+                # Has 'success' as a key
                 return json_body['success']
             # API can return a success 200 when service unavailable occurs
             return 'Service Unavailable' not in json_body


### PR DESCRIPTION
The SDK breaks when trying to run an API call that returns a string body (in csv format, for example).

This is what happens:
`json_body = self.json()`
* it fails to convert the body from string to dict, so it returns the string body itself.

`if isinstance(json_body, collections_abc.Mapping) and 'error' in json_body:`
* if fails because it checks if `json_body` is a dict when looking for a dictionary key in it

`elif bool(json_body):`
* it's basically just checking that `json_body` is not empty (str or dict) or False.

`if 'success' in json_body:`
* it doesn't check `json_body` is a dict
* whenever `json_body` is a string the code is looking for a substring instead of a dictionary key

`return json_body['success']`
* if the string body contains 'success', it will throw an exception when trying to use a string to index a string
* I've seen this happening when trying to read ad insights with 'success' in a campaign name

`return 'Service Unavailable' not in json_body`
* if the string body doesn't contain 'success' but it contains 'Service Unavailable', for any reason, this would return False even if the API call was successful.